### PR TITLE
Add --keep-literals-together flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,8 @@ If used, and output file exists, then the .pot file is updated.
 
 Ignore missing .po file.
 This should be used with `--keep-source-strings`.
+
+### --keep-literals-together
+
+When multiple literals (e.g. hyperlink, text, emphasis) are part of the same markdown block (i.e. paragraph) keep them as a single string.
+This results in a string containing markdown.

--- a/src/MarkdownLocalize.CLI/Program.cs
+++ b/src/MarkdownLocalize.CLI/Program.cs
@@ -104,6 +104,9 @@ namespace MarkdownLocalize.CLI
         [Option("--ignore-missing-po", "Write output if .po file is missing.", CommandOptionType.NoValue)]
         public bool IgnoreMissingPO { get; } = false;
 
+        [Option("--keep-literals-together", "Keep multiple literals within the same block as a single string.", CommandOptionType.NoValue)]
+        public bool KeepLiteralsTogether { get; } = false;
+
         private int OnExecute()
         {
             Console.OutputEncoding = System.Text.Encoding.UTF8;
@@ -278,6 +281,7 @@ namespace MarkdownLocalize.CLI
                 FrontMatterSourceKey = FrontMatterSourceKey,
                 UpdateFrontMatterLocale = UpdateFrontMatterLocale,
                 AddFrontMatterKeys = ParseFrontMatterKeys(),
+                KeepLiteralsTogether = KeepLiteralsTogether,
             });
         }
 

--- a/src/MarkdownLocalize.Markdown/RendererOptions.cs
+++ b/src/MarkdownLocalize.Markdown/RendererOptions.cs
@@ -28,4 +28,5 @@ public class RendererOptions
     public bool UpdateFrontMatterLocale { get; set; }
     public string Locale { get; set; }
     public Dictionary<string, string> AddFrontMatterKeys { get; set; }
+    public bool KeepLiteralsTogether = false;
 }

--- a/src/MarkdownLocalize.Markdown/TransformRenderer/ObjectRenderers/TransformRenderer.ContainerInlineRenderer.cs
+++ b/src/MarkdownLocalize.Markdown/TransformRenderer/ObjectRenderers/TransformRenderer.ContainerInlineRenderer.cs
@@ -212,8 +212,8 @@ namespace MarkdownLocalize.Markdown
                     renderer.PopElementType();
                 }
 
-                if (!obj.LastChild.Span.IsEmpty)
-                    renderer.MoveTo(obj.LastChild.Span.End + 1);
+                //if (!obj.LastChild.Span.IsEmpty)
+                //    renderer.MoveTo(obj.LastChild.Span.End + 1);
             }
 
             private void ProcessChild(TransformRenderer renderer, Inline child)

--- a/src/MarkdownLocalize.Markdown/TransformRenderer/TransformRenderer.cs
+++ b/src/MarkdownLocalize.Markdown/TransformRenderer/TransformRenderer.cs
@@ -128,6 +128,29 @@ namespace MarkdownLocalize.Markdown
             }
         }
 
+        private void WriteMultipleTogether(IEnumerable<Inline> childs, int index)
+        {
+            int startIndex = childs.Where(c => c.Span.Start > 0).First().Span.Start;
+            int endIndex = childs.Where(c => c.Span.End > 0).Last().Span.End;
+            string str = OriginalMarkdown.Substring(startIndex, endIndex - startIndex + 1);
+
+            int trimStartIndex = str.Length - str.TrimStart().Length;
+            string trimStart = str.Substring(0, trimStartIndex);
+            int trimEndIndex = str.TrimEnd().Length;
+            string trimEnd = str.Substring(trimEndIndex);
+
+            string transformedS = CheckTransform(str.Trim(), index, true);
+
+            if (transformedS == null)
+                throw new Exception("Missing translation for: " + str);
+
+            Write(trimStart);
+            Write(transformedS);
+            Write(trimEnd);
+
+            SkipTo(endIndex + 1);
+        }
+
         private void WriteMultiple(IEnumerable<Inline> childs, int index)
         {
             // Let's trim all lines, while saving trimmed text

--- a/test/MarkdownLocalize.Tests/MarkdownExtractStrings.cs
+++ b/test/MarkdownLocalize.Tests/MarkdownExtractStrings.cs
@@ -296,6 +296,9 @@ a = b
     [Fact]
     public void CodeBlockSurroundedByText()
     {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+        });
         IEnumerable<string> strings = MarkdownParser.ExtractStrings(@"See the following example:
 ```language
 a = b

--- a/test/MarkdownLocalize.Tests/MarkdownExtractStrings.cs
+++ b/test/MarkdownLocalize.Tests/MarkdownExtractStrings.cs
@@ -552,7 +552,83 @@ More text";
             "The first. *The second!" }, strings);
     }
 
+    [Fact]
+    public void MultipleLiteralsSeparate()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = false,
+        });
+        string md = @"  [Label](https://www.example.com) and text.  ";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "Label", "and text." }, strings);
+    }
 
 
+    [Fact]
+    public void MultipleLiteralsTogether()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = true,
+        });
+        string md = @"  [Label](https://www.example.com) and text.  ";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "[Label](https://www.example.com) and text.", "Label" }, strings);
+    }
+
+    [Fact]
+    public void MultipleLiteralsTogetherImage()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = true,
+        });
+        string md = @"![](image.png) Text ";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "Text" }, strings);
+    }
+
+    [Fact]
+    public void MultipleLiteralsTogetherBold()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = true,
+        });
+        string md = @"**Bold text**";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "Bold text" }, strings);
+    }
+
+    [Fact]
+    public void MultipleLiteralsTogetherBullet()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = true,
+        });
+        string md = @"* ![](image.png) Text ";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "Text" }, strings);
+    }
+
+    [Fact]
+    public void MultipleLiteralsTogetherBulletLink()
+    {
+        MarkdownParser.SetParserOptions(new RendererOptions()
+        {
+            KeepLiteralsTogether = true,
+        });
+        string md = @"* [Label](www.example.com)";
+
+        IEnumerable<string> strings = MarkdownParser.ExtractStrings(md, null).Select(si => si.String).Distinct();
+        Assert.Equal(new string[] { "Label" }, strings);
+    }
 
 }


### PR DESCRIPTION
Using `--keep-literals-together flag` allows to keep multiple literals together instead of breaking them into separate ones.
Using this option might extract strings containing markdown.